### PR TITLE
Change creation time to operation time

### DIFF
--- a/draft-ietf-cose-msg.xml
+++ b/draft-ietf-cose-msg.xml
@@ -600,10 +600,10 @@ header_map = {
               Details on computing counter signatures are found in <xref target="counter_signature"/>.
             </t>
 
-            <t hangText='creation time'>
-              This parameter provides the time the content was created.
+            <t hangText='operation time'>
+              This parameter provides the time the content cryptographic operation is performed.
               For signatures and recipient structures, this would be the time that the signature or recipient key object was created.
-              For content structures, this would be the time that the content was created.
+              For content structures, this would be the time that the content structure was created.
               The unsigned integer value is the number of seconds, excluding leap seconds; after midnight UTC, January 1, 1970.
             </t>
 
@@ -625,7 +625,7 @@ header_map = {
           <c>IV</c>         <c>5</c>        <c>bstr</c>              <c></c>                              <c>Full Initialization Vector</c>
           <c>Partial IV</c> <c>6</c>        <c>uint</c>              <c></c>                              <c>Partial Initialization Vector</c>
           <c>counter signature</c> <c>7</c> <c>COSE_signature</c>    <c></c>                              <c>CBOR encoded signature structure</c>
-          <c>creation time</c><c>*</c>      <c>uint</c>              <c></c>                              <c>Time the content was created</c>
+          <c>operation time</c><c>8</c>      <c>uint</c>              <c></c>                             <c>Time the COSE structure was created</c>
         </texttable>
 
         <t>
@@ -641,7 +641,8 @@ Generic_Headers = (
     ? 4 => bstr,        ; key identifier
     ? 5 => bstr,        ; IV
     ? 6 => uint,        ; Partial IV
-    ? 7 => COSE_signature ; Counter signature
+    ? 7 => COSE_signature, ; Counter signature
+    ? 8 => uint         ; Operation time
 )
 ]]></artwork></figure>
 

--- a/draft-ietf-cose-msg.xml
+++ b/draft-ietf-cose-msg.xml
@@ -605,6 +605,7 @@ header_map = {
               For signatures and recipient structures, this would be the time that the signature or recipient key object was created.
               For content structures, this would be the time that the content structure was created.
               The unsigned integer value is the number of seconds, excluding leap seconds; after midnight UTC, January 1, 1970.
+              The field is primarily intended to be to be used for countersignatures, however it can additionally be used for replay detection as well.
             </t>
 
           </list>


### PR DESCRIPTION
It makes sense that we do not talk about creation time of the content.  However the concept of having a time in the header is also very reasonable for things like countersignatures where one wants to make a timestamp as there is no content that the time marker can be placed in.

We therefore change the text to make the time field be the time that the cryptographic operation was performed at.