### PR TITLE
Use CDDL to define protected fields

### DIFF
--- a/draft-ietf-cose-msg.xml
+++ b/draft-ietf-cose-msg.xml
@@ -513,9 +513,10 @@ tag=10
 
       <figure><artwork type="CDDL"><![CDATA[
 header_map = {+ label => any }
+empty_or_serialized_map = bstr .cbor header_map / bstr .size 0
 
 Headers = (
-    protected : bstr,                  ; Contains a header_map
+    protected : empty_or_serialized_map,
     unprotected : header_map
 )
 ]]></artwork></figure>
@@ -860,8 +861,8 @@ COSE_signature =  [
 
         <figure><artwork type="CDDL"><![CDATA[
 Sig_structure = [
-    body_protected: bstr,
-    sign_protected: bstr,
+    body_protected: empty_or_serialized_map,
+    sign_protected: empty_or_serialized_map,
     external_aad: bstr,
     payload: bstr
 ]
@@ -1123,7 +1124,7 @@ COSE_encryptData = [
 
         <figure><artwork type="CDDL"><![CDATA[
 Enc_structure = [
-    protected: bstr,
+    protected: empty_or_serialized_map,
     external_aad: bstr
 ]
 
@@ -1283,7 +1284,7 @@ COSE_Mac = [
 
           <figure><artwork type="CDDL"><![CDATA[
 MAC_structure = [
-     protected: bstr,
+     protected: empty_or_serialized_map,
      external_aad: bstr,
      payload: bstr
 ]
@@ -2247,7 +2248,7 @@ COSE_KDF_Context = [
     ],
     SuppPubInfo : [
         keyDataLength : uint,
-        protected : bstr,
+        protected : empty_or_serialized_map,
         ? other : bstr
     ],
     ? SuppPrivInfo : bstr


### PR DESCRIPTION
CDDL has "annotators" to describe what structure is encoded in CBOR serialized as binary strings.
I suggest we make use of that.
(Please double-check that I hit all the right places.)