### PR TITLE
Update the title and the context structure

### DIFF
--- a/draft-ietf-cose-msg.xml
+++ b/draft-ietf-cose-msg.xml
@@ -2777,8 +2777,8 @@ valid, message content = Decrypt(cipher text, key, additional data)
 
       <figure><artwork type='CDDL'><![CDATA[
 PartyInfo = (
-    nonce : bstr / int / nil,
     identity : bstr / nil,
+    nonce : bstr / int / nil,
     other : bstr / nil,
 )
 

--- a/draft-ietf-cose-msg.xml
+++ b/draft-ietf-cose-msg.xml
@@ -66,7 +66,7 @@
 
 <rfc ipr="trust200902" docName="draft-ietf-cose-msg-latest" category="std">
   <front>
-    <title>CBOR Encoded Message Syntax</title>
+    <title>COSE: A Message Based Security Solution for CBOR</title>
 
     <author initials="J." surname="Schaad" fullname="Jim Schaad">
       <organization>August Cellars</organization>
@@ -83,8 +83,9 @@
       <t>
         Concise Binary Object Representation (CBOR) is data format designed for small code size and small message size.
         There is a need for the ability to have the basic security services defined for this data format.
-        This document specifies processing for signatures, message authentication codes, and encryption using CBOR.
-        This document also specifies a representation for cryptographic keys using CBOR.
+        This document defines the CBOR Object Signing and Encyption (COSE) specification.
+        This specification describes how to create and process signature, message authentication codes and encryption using CBOR for serialization.
+        This specifiction additionally specifies how to representat cryptographic keys using CBOR.
       </t>
     </abstract>
 
@@ -2700,7 +2701,7 @@ valid, message content = Decrypt(cipher text, key, additional data)
                   We define an algorithm parameter 'PartyU identity' that can be used to carry identity information in the message.
                   However, identity information is often known as part of the protocol and can thus be inferred rather than made explicit.
                   If identity information is carried in the message, applications SHOULD have a way of validating the supplied identity information.
-                  The identity information does not need to be specified and can be left as absent.
+                  The identity information does not need to be specified and is set to nil in that case.
                 </t>
 
                 <t hangText="nonce">
@@ -2710,13 +2711,13 @@ valid, message content = Decrypt(cipher text, key, additional data)
                   We define an algorithm parameter 'PartyU nonce' that can be used to carry this value in the message
                   However, the nonce value could be determined by the application and the value determined from elsewhere.
                   <vspace/>
-                  This item is optional and can be absent.
+                  This option does not need to be specified and is set to nil in that case
                 </t>
 
                 <t hangText="other">
                   This contains other information that is defined by the protocol.
                   <vspace/>
-                  This item is optional and can be absent.
+                  This option does not need to be specified and is set to nil in that case
                 </t>
               </list>
             </t>
@@ -2776,9 +2777,9 @@ valid, message content = Decrypt(cipher text, key, additional data)
 
       <figure><artwork type='CDDL'><![CDATA[
 PartyInfo = (
-    ? nonce : bstr / int,
-    ? identity : bstr,
-    ? other : bstr,
+    nonce : bstr / int / nil,
+    identity : bstr / nil,
+    other : bstr / nil,
 )
 
 COSE_KDF_Context = [

--- a/includes/Appendix_A.xml
+++ b/includes/Appendix_A.xml
@@ -17,8 +17,8 @@
         / unprotected / {
           / alg / 1:-3 / A128KW /
         }, 
-        / ciphertext / h'f4b117264ab6d4d1476e0204bb15db58c5834461e83
-5e884', 
+        / ciphertext / h'dbd43c4e9d719c27c6275c67d628d493f090593db82
+18f11', 
         / recipients / [
           [
             / protected / h'a1013818' / {

--- a/includes/Appendix_B_3_1.xml
+++ b/includes/Appendix_B_3_1.xml
@@ -1,4 +1,4 @@
-<t>Size of binary file is 185 bytes</t>
+<t>Size of binary file is 152 bytes</t>
 
 <figure><artwork type='CBORdiag'><![CDATA[
 992(
@@ -9,8 +9,8 @@
     / unprotected / {
       / iv / 5:h'c9cf4df2fe6c632bf7886413'
     }, 
-    / ciphertext / h'40970cd7ab5fbd10f505bf7a86e6fc0a99a3122475fbed3
-36488c3220f884f011ba219ea', 
+    / ciphertext / h'7adbe2709ca818fb415f1e5df66f4e1a51053ba6d65a1a0
+c52a357da7a644b8070a151b0', 
     / recipients / [
       [
         / protected / h'a1013818' / {
@@ -22,8 +22,7 @@
             / crv / -1:1, 
             / x / -2:h'98f50a4ff6c05861c8860d13a638ea56c3f5ad7590bbf
 bf054e1c7b4d91d6280', 
-            / y / -3:h'f01400b089867804b8e9fc96c3932161f1934f4223069
-170d924b7e03bf822bb'
+            / y / -3:true
           }, 
           / kid / 4:'meriadoc.brandybuck@buckland.example'
         }, 

--- a/includes/Appendix_B_3_2.xml
+++ b/includes/Appendix_B_3_2.xml
@@ -9,8 +9,8 @@
     / unprotected / {
       / iv / 5:h'89f52f65a1c580933b5261a76c'
     }, 
-    / ciphertext / h'89bedc91e9909346a8fe87834445679ee12b2c95f57feed
-836e6d4bd', 
+    / ciphertext / h'753548a19b1307084ca7b2056924ed95f2e3b17006dfe93
+1b687b847', 
     / recipients / [
       [
         / protected / h'a10129' / {

--- a/includes/Appendix_B_3_3.xml
+++ b/includes/Appendix_B_3_3.xml
@@ -1,4 +1,4 @@
-<t>Size of binary file is 360 bytes</t>
+<t>Size of binary file is 327 bytes</t>
 
 <figure><artwork type='CBORdiag'><![CDATA[
 992(
@@ -17,13 +17,13 @@
         }, 
         / signature / h'00aa98cbfd382610a375d046a275f30266e8d0faacb9
 069fde06e37825ae7825419c474f416ded0c8e3e7b55bff68f2a704135bdf99186f6
-6659461c8cf929cc7fb301d57eb4d42d95dc0a61b72ee49dda4ce431d434dc7e02c2
-cdff49d9189cfbffdaf0444f10bfe9a9ebd96bee2c0d76743936f6f56ac62c8ed4d3
-ee3758390d877901'
+6659461c8cf929cc7fb300f5e2b33c3b433655042ff719804ff73b0be3e988ecebc0
+c70ef6616996809c6eb59a918dbe0a5edb0d15137ece0aba2a0b0f68ad2631cb62f2
+ea4d7099804218b0'
       ]
     }, 
-    / ciphertext / h'40970cd7ab5fbd10f505bf7a86e6fc0a99a3122475fbed3
-36488c3220f884f011ba219ea', 
+    / ciphertext / h'7adbe2709ca818fb415f1e5df66f4e1a51053ba6d65a1a0
+c52a357da7a644b8070a151b0', 
     / recipients / [
       [
         / protected / h'a1013818' / {
@@ -35,8 +35,7 @@ ee3758390d877901'
             / crv / -1:1, 
             / x / -2:h'98f50a4ff6c05861c8860d13a638ea56c3f5ad7590bbf
 bf054e1c7b4d91d6280', 
-            / y / -3:h'f01400b089867804b8e9fc96c3932161f1934f4223069
-170d924b7e03bf822bb'
+            / y / -3:true
           }, 
           / kid / 4:'meriadoc.brandybuck@buckland.example'
         }, 

--- a/includes/Appendix_B_3_4.xml
+++ b/includes/Appendix_B_3_4.xml
@@ -21,8 +21,8 @@ e5f0165eee976b4a5f6c6f09d',
           / kid / 4:'meriadoc.brandybuck@buckland.example', 
           / U nonce / -22:h'0101'
         }, 
-        / ciphertext / h'59463342fd2193f30daeb1ebb2dc7310b56cee0939d
-d6692'
+        / ciphertext / h'41e0d76f579dbd0d936a662d54d8582037de2e366fd
+e1c62'
       ]
     ]
   ]

--- a/includes/Appendix_B_5_2.xml
+++ b/includes/Appendix_B_5_2.xml
@@ -8,8 +8,8 @@
       } / , 
     / unprotected / {}, 
     / payload / 'This is the content.', 
-    / tag / h'42cf68ae1253948c500dff27da3904342625a23e914f7aa545dcf6
-629519f18e', 
+    / tag / h'81a03448acd3d305376eaa11fb3fe416a955be2cbe7ec96f012c99
+4bc3f16a41', 
     / recipients / [
       [
         / protected / h'a101381a' / {

--- a/includes/Appendix_B_5_4.xml
+++ b/includes/Appendix_B_5_4.xml
@@ -1,4 +1,4 @@
-<t>Size of binary file is 377 bytes</t>
+<t>Size of binary file is 310 bytes</t>
 
 <figure><artwork type='CBORdiag'><![CDATA[
 994(
@@ -22,14 +22,12 @@
             / x / -2:h'0043b12669acac3fd27898ffba0bcd2e6c366d53bc4db
 71f909a759304acfb5e18cdc7ba0b13ff8c7636271a6924b1ac63c02688075b55ef2
 d613574e7dc242f79c3', 
-            / y / -3:h'00812dd694f4ef32b11014d74010a954689c6b6e8785b
-333d1ab44f22b9d1091ae8fc8ae40b687e5cfbe7ee6f8b47918a07bb04e9f5b1a51a
-334a16bc09777434113'
+            / y / -3:true
           }, 
           / kid / 4:'bilbo.baggins@hobbiton.example'
         }, 
-        / ciphertext / h'c07072310285bbd3f0675774418138e14388ed47a4a
-81219d42a8bfbe3a5559c19de83435d21c6bc'
+        / ciphertext / h'339bc4f79984cdc6b3e6ce5f315a4c7d2b0ac466fce
+a69e8c07dfbca5bb1f661bc5f8e0df9e3eff5'
       ], 
       [
         / protected / h'', 


### PR DESCRIPTION
We change the title of the document
Implement the suggested change from Carsten that we put nils in to unused elements in the ParytInfo structure.  I was a bit more complete than the original suggestion but it is probably simpler to get right that way.