### PR TITLE
Fix when static keys should be used

### DIFF
--- a/draft-ietf-cose-msg.xml
+++ b/draft-ietf-cose-msg.xml
@@ -3211,7 +3211,7 @@ COSE_KDF_Context = [
             <ttcol>algorithm</ttcol>
             <ttcol>description</ttcol>
             <c>ephemeral key</c>        <c>-1</c>       <c>COSE_Key</c>         <c>ECDH-ES</c>  <c>Ephemeral Public key for the sender</c>
-            <c>static key</c>           <c>-2</c>       <c>COSE_Key</c>         <c>ECDH-ES</c>  <c>Static Public key for the sender</c>
+            <c>static key</c>           <c>-2</c>       <c>COSE_Key</c>         <c>ECDH-SS</c>  <c>Static Public key for the sender</c>
             <c>static key id </c>       <c>-3</c>       <c>bstr</c>             <c>ECDH-SS</c>  <c>Static Public key identifier for the sender</c>
           </texttable>
 


### PR DESCRIPTION
This are for ECDH-SS not ECDH-ES algorithms.  Thanks to Adam.